### PR TITLE
Simplify attribute_set class, renamed from pattern_value_set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(codeowners
         include/codeowners/git.hpp
         src/codeowners.cpp
         src/errors.cpp
-        src/git.cpp)
+        src/git.cpp include/codeowners/types.hpp)
 target_include_directories(codeowners
         PUBLIC include
         PRIVATE external/libgit2/include

--- a/include/codeowners/codeowners.hpp
+++ b/include/codeowners/codeowners.hpp
@@ -1,63 +1,25 @@
 #pragma once
 
-#include "codeowners/filesystem.hpp"
+#include "codeowners/types.hpp"
 
 #include <memory>
-#include <optional>
+#include <string>
+#include <vector>
 
 namespace co
 {
 
-struct owner
+/// Class that identifies a code owner.  This is a strong typedef around a string.
+struct owner : public strong_typedef<owner, std::string>, equality_comparable<owner>, streamable<owner>
 {
-    std::string name;
+    using strong_typedef::strong_typedef;
 };
 
-struct source_location
-{
-    fs::path filename;
-    std::string basename;
-    std::int32_t line_number;
-};
-
+/// Class holding a code ownership rule, corresponding to a single record in CODEOWNERS file.
 struct ownership_rule
 {
-    source_location source_location;
+    std::string pattern;
+    std::vector<owner> owners;
 };
 
-//class repository
-//{
-//public:
-//    repository(const fs::path& repository_root);
-//    ~repository();
-//    static repository find(const fs::path& path);
-//
-//    bool contains(const fs::path& path) const;
-//    std::vector<fs::path> index_paths() const;
-//
-//private:
-//    const repository_impl* impl() const;
-//    repository_impl* impl();
-//
-//    std::unique_ptr<repository_impl> m_impl;
-//};
-//
-//std::optional<fs::path> codeowners_file(const fs::path& repo_root);
-//
-//struct file_pattern
-//{
-//    const std::string pattern;
-//    const bool invert = false;
-//
-//    bool match(const fs::path& path) const { return match(path.c_str()); }
-//    bool match(const std::string& path) const { return match(path.c_str()); }
-//    bool match(const char* path) const;
-//};
-//
-//struct owner_rule
-//{
-//    file_pattern pattern;
-//    std::vector<std::string> owners;
-//};
-//
 }  // end namespace 'co'

--- a/include/codeowners/codeowners.hpp
+++ b/include/codeowners/codeowners.hpp
@@ -8,42 +8,56 @@
 namespace co
 {
 
-struct repository_impl;
-
-
-class repository
+struct owner
 {
-public:
-    repository(const fs::path& repository_root);
-    ~repository();
-    static repository find(const fs::path& path);
-
-    bool contains(const fs::path& path) const;
-    std::vector<fs::path> index_paths() const;
-
-private:
-    const repository_impl* impl() const;
-    repository_impl* impl();
-
-    std::unique_ptr<repository_impl> m_impl;
+    std::string name;
 };
 
-std::optional<fs::path> codeowners_file(const fs::path& repo_root);
-
-struct file_pattern
+struct source_location
 {
-    const std::string pattern;
-    const bool invert = false;
-
-    bool match(const fs::path& path) const { return match(path.c_str()); }
-    bool match(const std::string& path) const { return match(path.c_str()); }
-    bool match(const char* path) const;
+    fs::path filename;
+    std::string basename;
+    std::int32_t line_number;
 };
 
-struct owner_rule
+struct ownership_rule
 {
-    file_pattern pattern;
-    std::vector<std::string> owners;
+    source_location source_location;
 };
 
+//class repository
+//{
+//public:
+//    repository(const fs::path& repository_root);
+//    ~repository();
+//    static repository find(const fs::path& path);
+//
+//    bool contains(const fs::path& path) const;
+//    std::vector<fs::path> index_paths() const;
+//
+//private:
+//    const repository_impl* impl() const;
+//    repository_impl* impl();
+//
+//    std::unique_ptr<repository_impl> m_impl;
+//};
+//
+//std::optional<fs::path> codeowners_file(const fs::path& repo_root);
+//
+//struct file_pattern
+//{
+//    const std::string pattern;
+//    const bool invert = false;
+//
+//    bool match(const fs::path& path) const { return match(path.c_str()); }
+//    bool match(const std::string& path) const { return match(path.c_str()); }
+//    bool match(const char* path) const;
+//};
+//
+//struct owner_rule
+//{
+//    file_pattern pattern;
+//    std::vector<std::string> owners;
+//};
+//
 }  // end namespace 'co'

--- a/include/codeowners/types.hpp
+++ b/include/codeowners/types.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <boost/operators.hpp>
+#include <type_traits>
+
+namespace co
+{
+
+template <typename Tag, typename T>
+struct strong_typedef
+{
+    using type = T;
+
+    template <typename = std::enable_if_t<std::is_default_constructible<T>::value>>
+    explicit strong_typedef()
+        : m_value {}
+    {
+    }
+
+    explicit strong_typedef(const T& value)
+        : m_value { value }
+    {
+    }
+    explicit strong_typedef(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
+        : m_value { std::move(value) }
+    {
+    }
+
+    const T& value() const& noexcept { return m_value; }
+    const T& value() const&& noexcept = delete;
+    T& value() & noexcept { return m_value; }
+    T& value() && noexcept = delete;
+
+    explicit operator T&() noexcept { return value(); }
+    explicit operator const T&() const noexcept { return value(); }
+
+    friend void swap(strong_typedef& a, strong_typedef& b) noexcept(std::is_nothrow_swappable_v<T>)
+    {
+        using std::swap;
+        swap(static_cast<T&>(a), static_cast<T&>(b));
+    }
+
+private:
+    T m_value;
+};
+
+template <typename StrongTypedef>
+using underlying_type_t = typename StrongTypedef::type;
+
+template <typename S>
+struct equality_comparable : boost::equality_comparable<S>
+{
+    friend bool operator==(const S& a, const S& b)
+    {
+        using T = underlying_type_t<S>;
+        return static_cast<const T&>(a) == static_cast<const T&>(b);
+    }
+};
+
+template <typename S, typename T>
+struct underlying_equality_comparable : equality_comparable<S>,
+                                        boost::equality_comparable<S, T>
+{
+    friend bool operator==(const S& a, const T& b)
+    {
+        return static_cast<const T&>(a) == b;
+    }
+};
+
+}  // end namespace 'co'

--- a/include/codeowners/types.hpp
+++ b/include/codeowners/types.hpp
@@ -67,4 +67,29 @@ struct underlying_equality_comparable : equality_comparable<S>,
     }
 };
 
+template <typename S>
+struct ostreamable
+{
+    friend std::ostream& operator<<(std::ostream& os, const S& s)
+    {
+        os << s.value();
+        return os;
+    }
+};
+
+template <typename S>
+struct istreamable
+{
+    friend std::istream& operator>>(std::istream& is, S& s)
+    {
+        is >> s.value();
+        return is;
+    }
+};
+
+template <typename S>
+struct streamable : ostreamable<S>, istreamable<S>
+{
+};
+
 }  // end namespace 'co'

--- a/src/codeowners.cpp
+++ b/src/codeowners.cpp
@@ -2,7 +2,6 @@
 #include <codeowners/errors.hpp>
 #include <codeowners/filesystem.hpp>
 
-
 #include <iostream>
 #include <memory>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # TEST EXECUTABLE
 add_executable(codeowners_tests
-        codeowners.t.cpp filesystem.t.cpp git.t.cpp)
+        codeowners.t.cpp filesystem.t.cpp git.t.cpp types.t.cpp)
 
 target_compile_options(codeowners_tests PRIVATE ${STRICT_COMPILE_OPTIONS})
 target_link_libraries(codeowners_tests

--- a/tests/git.t.cpp
+++ b/tests/git.t.cpp
@@ -15,32 +15,32 @@ TEST(create_repository_test, creates_repository)
     ASSERT_TRUE(repo_ptr);
 };
 
-TEST(pattern_value_set, construction)
+TEST(attribute_set, construction)
 {
     const std::string attribute_name { "my_attribute" };
-    pattern_value_set pvs { attribute_name };
-    EXPECT_EQ(pvs.attribute_name(), attribute_name);
+    attribute_set attr_set { attribute_name };
+    EXPECT_EQ(attr_set.attribute_name(), attribute_name);
 };
 
 TEST(pattern_value_set, pattern)
 {
     const std::string attribute_name { "my_attribute" };
-    pattern_value_set pvs { attribute_name };
+    attribute_set attr_set { attribute_name };
+    attr_set.add_pattern(pattern { "*.hpp" }, "x");
+    attr_set.add_pattern(pattern { "*.cpp" }, "y");
 
-    pvs.add_pattern("sample.hpp", 42);
-    EXPECT_EQ(pvs.get<int>("sample.hpp"), 42);
-
-    EXPECT_EQ(pvs.attribute_name(), attribute_name);
+    EXPECT_EQ(attr_set.get("sample.hpp"), "x");
+    EXPECT_EQ(attr_set.get("sample.cpp"), "y");
 };
 
 TEST(pattern_value_set, undefined_value)
 {
     const std::string attribute_name { "my_attribute" };
-    pattern_value_set pvs { attribute_name };
+    attribute_set attr_set { attribute_name };
+    attr_set.add_pattern(pattern { "*.hpp" }, "foo");
 
-    pvs.add_pattern("*.hpp", 42);
-    EXPECT_FALSE(bool(pvs.get_optional<int>("unmatched_file")));
-    EXPECT_THROW(pvs.get<int>("unmatched_file"), pattern_value_set::no_attribute_value);
+    EXPECT_FALSE(bool(attr_set.get_optional("unmatched_file")));
+    EXPECT_THROW(attr_set.get("unmatched_file"), attribute_set::no_attribute_error);
 };
 
 }  // end namespace 'testing'

--- a/tests/types.t.cpp
+++ b/tests/types.t.cpp
@@ -7,7 +7,7 @@ namespace co
 namespace testing
 {
 
-struct X : public strong_typedef<X, int>, equality_comparable<X>
+struct X : public strong_typedef<X, int>, equality_comparable<X>, streamable<X>
 {
     using strong_typedef::strong_typedef;
 };
@@ -34,6 +34,31 @@ TEST(strong_typedef_test, heterogeneous_comparison)
     EXPECT_EQ(1, Y(1));
     EXPECT_NE(Y(0), 1);
     EXPECT_NE(1, Y(0));
+};
+
+TEST(strong_typedef_test, streamable)
+{
+    X x(4);
+    std::ostringstream os;
+    os << x;
+    EXPECT_EQ(os.str(), "4");
+
+    // Test round-trip
+    {
+        X x2;
+        std::stringstream ss;
+        ss << x;
+        ss >> x2;
+        EXPECT_EQ(x, x2) << "Contents of ss: " << ss.str();
+    }
+};
+
+TEST(strong_typedef_test, streamable_with_errors)
+{
+    X x;
+    std::stringstream ss("foo");
+    ss >> x;
+    EXPECT_TRUE(ss.fail());
 };
 
 }  // end namespace 'testing'

--- a/tests/types.t.cpp
+++ b/tests/types.t.cpp
@@ -1,0 +1,40 @@
+#include "codeowners/types.hpp"
+
+#include <gtest/gtest.h>
+
+namespace co
+{
+namespace testing
+{
+
+struct X : public strong_typedef<X, int>, equality_comparable<X>
+{
+    using strong_typedef::strong_typedef;
+};
+
+struct Y : public strong_typedef<Y, int>, underlying_equality_comparable<Y, int>
+{
+    using strong_typedef::strong_typedef;
+};
+
+TEST(strong_typedef_test, comparison)
+{
+    EXPECT_EQ(X(), X(0));
+    EXPECT_EQ(X(1), X(1));
+    EXPECT_NE(X(0), X(1));
+    X x(1);
+    EXPECT_EQ(x.value(), 1);
+    x.value() = 0;
+    EXPECT_EQ(x.value(), 0);
+};
+
+TEST(strong_typedef_test, heterogeneous_comparison)
+{
+    EXPECT_EQ(Y(1), 1);
+    EXPECT_EQ(1, Y(1));
+    EXPECT_NE(Y(0), 1);
+    EXPECT_NE(1, Y(0));
+};
+
+}  // end namespace 'testing'
+}  // end namespace 'co'


### PR DESCRIPTION
### Changes

* Simplified `pattern_value_set` class, renaming it to `attribute_set`.  The class no longer has templated member functions for converting to arbitrary types, but instead handles string values only (like the underlying `.gitattributes` mechanism).
* Introduced some simple types in `codeowners.hpp`
 