### PR TITLE
Update Github issue template to simplify it

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,21 +2,7 @@
 
 Summary or short description of this issue. 
 
-### Environment
-
-* codeowners version:  output of `codeowners --version`
-* Operating system:  e.g. Mac OS X 10.13.6 or Ubuntu 18.04.2
-
-### Steps to reproduce
-
-Ideally, this will be a 
-[minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example)
-that illustrates the problem.
-
-### Expected behavior
-
-Description of how the program ought to behave.
-
-### Actual behavior
-
-Description of how the program actually behaves.
+For bug reports (or feature requests, where applicable), including a 
+[minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example), 
+as well as a clear statement of desired behavior, will greatly increase 
+the ability of contributors to diagnose and fix issues.


### PR DESCRIPTION
Remove headers in Github issue template.  These headers were most applicable to bugs, but at this point, most issues will be feature/enhancement requests.

